### PR TITLE
add icons directory to the list of required paths

### DIFF
--- a/terminal-notifier-guard.gemspec
+++ b/terminal-notifier-guard.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage         = 'https://github.com/Springest/terminal-notifier-guard'
 
   gem.files            = ['lib/terminal-notifier-guard.rb']
-  gem.require_paths    = ['lib']
+  gem.require_paths    = ['lib','icons']
 
   gem.extra_rdoc_files = ['README.markdown']
 


### PR DESCRIPTION
I have installed version 1.6.1 on OS X 10.10, but unfortunately the icons are not included into the gem.
