### PR TITLE
add icons to the list of files

### DIFF
--- a/terminal-notifier-guard.gemspec
+++ b/terminal-notifier-guard.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email            = ["wouter@springest.com"]
   gem.homepage         = 'https://github.com/Springest/terminal-notifier-guard'
 
-  gem.files            = ['lib/terminal-notifier-guard.rb']
+  gem.files            = ['lib/terminal-notifier-guard.rb'] + Dir['icons/*']
   gem.require_paths    = ['lib']
 
   gem.extra_rdoc_files = ['README.markdown']


### PR DESCRIPTION
I have installed version 1.6.1 on OS X 10.10, but unfortunately the icons are not included into the gem. I have now added them to the spec's files list.
