### PR TITLE
Invoke 'terminal-notifier -help' for binary detection

### DIFF
--- a/lib/terminal-notifier-guard.rb
+++ b/lib/terminal-notifier-guard.rb
@@ -10,7 +10,8 @@ module TerminalNotifier
 
     def self.terminal_notifier_version
       return Gem::Version("0.0.0") unless installed?
-      Gem::Version.new(`#{bin_path}`.lines.first.match(/\d\.\d\.\d/)[0])
+      # invoke the help option since the binary otherwise may get stuck
+      Gem::Version.new(`#{bin_path} -help`.lines.first.match(/\d\.\d\.\d/)[0])
     rescue
       Gem::Version.new("0.0.0")
     end


### PR DESCRIPTION
Hi Eloy,

when I included your gem into my Guard setup the execution got stuck on the changed line (said the debugger). I found out that the execution does not respond, even after more than 10s. I tried a couple of things, but changing the command to include the _help_ option actually seems to work fine.

Can you verify that the changed version also runs on other systems, which apparently did not have issues before.

My System:
Ruby 2.1.3
OS X 10.10

Greetings
Cedric