### PR TITLE
Specify license on gemspec

### DIFF
--- a/terminal-notifier-guard.gemspec
+++ b/terminal-notifier-guard.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.summary          = 'Send User Notifications on Mac OS X 10.8 - with status icons.'
   gem.authors          = ["Eloy Duran", "Wouter de Vos"]
   gem.email            = ["wouter@springest.com"]
+  gem.license          = 'MIT'
   gem.homepage         = 'https://github.com/Springest/terminal-notifier-guard'
 
   gem.files            = ['lib/terminal-notifier-guard.rb'] + Dir['icons/*']


### PR DESCRIPTION
Hey there,

We're using an automated tool called License Finder (https://github.com/pivotal/LicenseFinder) and your gem comes up as "Unknown". By adding the license to the gemspec file you would help immensely users of this and other automated tools to figure out whether a gem can be used inside another project.

Thanks!