### PR TITLE
Allow bin_path to be specified via env variable

### DIFF
--- a/lib/terminal-notifier-guard.rb
+++ b/lib/terminal-notifier-guard.rb
@@ -41,7 +41,9 @@ module TerminalNotifier
     end
 
     def self.bin_path
-      @@binary ||= `which terminal-notifier`.chomp
+      ENV["TERMINAL_NOTIFIER_BIN"] || begin
+        @@binary ||= `which terminal-notifier`.chomp
+      end
     end
 
     def self.execute(verbose, options)

--- a/spec/terminal-notifier-guard_spec.rb
+++ b/spec/terminal-notifier-guard_spec.rb
@@ -126,4 +126,19 @@ describe "TerminalNotifier::Guard" do
       TerminalNotifier::Guard.list.class.should == Array
     end
   end
+
+  describe ".bin_path" do
+    before do
+      @orig_env = ENV["TERMINAL_NOTIFIER_BIN"]
+    end
+
+    after do
+      ENV["TERMINAL_NOTIFIER_BIN"] = @orig_env
+    end
+
+    it "uses TERMINAL_NOTIFIER_BIN env variable if present" do
+      ENV["TERMINAL_NOTIFIER_BIN"] = "/my/custom/bin"
+      TerminalNotifier::Guard.bin_path.should.equal("/my/custom/bin")
+    end
+  end
 end


### PR DESCRIPTION
This solves a problem where the default binary found by `which` is the Ruby gem version of `terminal-notifier`. This version is slow, especially in a Bundler environment.

In this scenario we would much rather use the Homebrew-installed version at `/usr/local/bin/terminal-notifier` which is noticeably faster.

This commit allows us to set an environment variable to explicitly specify the binary to use, like this:

```
export TERMINAL_NOTIFIER_BIN=/usr/local/bin/terminal-notifier
```

When using guard to monitor test results in TDD, speed is of the essence. Using the right binary can save a half second or more during each test run, which doesn't seem like much but makes a big difference in productivity.