### PR TITLE
Play sound for notifications when they execute.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,13 +4,13 @@ A simple Ruby wrapper around the [`terminal-notifier`](https://github.com/alloy/
 tool, which allows you to send User Notifications to the Notification Center on
 Mac OS X 10.8, or higher.
 
-This version has 4 different icons included for each status that
+This version has 4 different icons and sounds included for each status that
 [Guard][GUARD] supports:
 
- 1. Failed
- 2. Notify
- 3. Pending
- 4. Success
+ 1. Failed (Sound is Sosumi)
+ 2. Notify (Sound is Blow)
+ 3. Pending (Sound is Morse)
+ 4. Success (Sound is Hero)
 
 
 ## Installation

--- a/lib/terminal-notifier-guard.rb
+++ b/lib/terminal-notifier-guard.rb
@@ -3,6 +3,7 @@ module TerminalNotifier
     VERSION = "1.7.0"
     ICONS_PATH = File.expand_path("../../icons", __FILE__)
     GUARD_ICON = File.join(ICONS_PATH, 'Guard.icns')
+    OSX_BUILT_IN_SOUNDS = { :notify => 'Blow', :failed => 'Sosumi', :pending => 'Morse', :success => 'Hero' }.freeze
 
     def self.osx_version
       Gem::Version.new(`sw_vers -productVersion`.strip)
@@ -49,7 +50,8 @@ module TerminalNotifier
 
     def self.execute(verbose, options)
       if available? && installed?
-        options.merge!({ :contentImage=> GUARD_ICON, :appIcon => icon(options.delete(:type)) })
+        type = options.delete(:type)
+        options.merge!({ :contentImage=> GUARD_ICON, :appIcon => icon(type), :sound => sound(type) })
 
         command = [bin_path, *options.map { |k,v| ["-#{k}", v.to_s] }.flatten]
         if RUBY_VERSION < '1.9'
@@ -116,6 +118,12 @@ module TerminalNotifier
       File.join(ICONS_PATH, file_name)
     end
     module_function :icon
+
+    def sound(type = :notify)
+      type ||= :notify
+      OSX_BUILT_IN_SOUNDS[type.to_sym]
+    end
+    module_function :sound
 
     # Removes a notification that was previously sent with the specified
     # ‘group’ ID, if one exists.

--- a/spec/terminal-notifier-guard_spec.rb
+++ b/spec/terminal-notifier-guard_spec.rb
@@ -11,7 +11,7 @@ require 'terminal-notifier-guard'
 describe "TerminalNotifier::Guard" do
   describe ".execute" do
     it "executes the tool with the given options" do
-      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon]
+      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon, '-sound', TerminalNotifier::Guard.sound]
       if RUBY_VERSION < '1.9'
         require 'shellwords'
         command = Shellwords.shelljoin(command)
@@ -20,8 +20,8 @@ describe "TerminalNotifier::Guard" do
       TerminalNotifier::Guard.execute(false, :message => 'ZOMG')
     end
 
-    it "executes with the right icon path according to the type option" do
-      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:success)]
+    it "executes with the right icon path and sound according to the type option" do
+      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:success), '-sound', TerminalNotifier::Guard.sound(:success)]
       if RUBY_VERSION < '1.9'
         require 'shellwords'
         command = Shellwords.shelljoin(command)
@@ -86,8 +86,8 @@ describe "TerminalNotifier::Guard" do
   end
 
   describe ".failed" do
-    it "executes with the 'failed' icon flag" do
-      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:failed)]
+    it "executes with the 'failed' icon flag and sound flag" do
+      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:failed), '-sound', TerminalNotifier::Guard.sound(:failed)]
       if RUBY_VERSION < '1.9'
         require 'shellwords'
         command = Shellwords.shelljoin(command)
@@ -98,8 +98,8 @@ describe "TerminalNotifier::Guard" do
   end
 
   describe ".success" do
-    it "executes with the 'success' icon flag" do
-      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:success)]
+    it "executes with the 'success' icon flag and sound flag" do
+      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:success), '-sound', TerminalNotifier::Guard.sound(:success)]
       if RUBY_VERSION < '1.9'
         require 'shellwords'
         command = Shellwords.shelljoin(command)
@@ -110,8 +110,8 @@ describe "TerminalNotifier::Guard" do
   end
 
   describe ".pending" do
-    it "executes with the 'pending' icon flag" do
-      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:pending)]
+    it "executes with the 'pending' icon flag and sound flag" do
+      command = [TerminalNotifier::Guard.bin_path, '-message', 'ZOMG', '-contentImage', TerminalNotifier::Guard::GUARD_ICON, '-appIcon', TerminalNotifier::Guard.icon(:pending), '-sound', TerminalNotifier::Guard.sound(:pending) ]
       if RUBY_VERSION < '1.9'
         require 'shellwords'
         command = Shellwords.shelljoin(command)


### PR DESCRIPTION
I added the new feature which play sound for notifications,
in order to make easier for user to notice them.

Play different sounds which built in OSX for each status:
1. Failed (Sound is Sosumi)
2. Notify (Sound is Blow)
3. Pending (Sound is Morse)
4. Success (Sound is Hero)

These 4 mappings from status to sounds are hard coded in the constant OSX_BUILT_IN_SOUNDS.
If you want to fix it (e.g. create file for sound configuration), I'll do it.
