### PR TITLE
Add `terminal-notifier` runtime dependency

### DIFF
--- a/terminal-notifier-guard.gemspec
+++ b/terminal-notifier-guard.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |gem|
   gem.require_paths    = ['lib']
 
   gem.extra_rdoc_files = ['README.markdown']
+  
+  gem.add_runtime_dependency 'terminal-notifier'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bacon'


### PR DESCRIPTION
I had this problem `Gem::Exception: can't find executable terminal-notifier`.

I am using rbenv and could not figure out why running `terminal-notifier` failed even when running in the shell.

After a long search I found the issue that the gem `terminal-notifier` was not in the Gemfile.lock.
I added it manually to `Gemfile` but adding this dependency should fix it in a better way.